### PR TITLE
build: Remove webpack in favor of ts-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Setup
 
 1. Clone this repo `git clone https://github.com/clarkdowner/four-seam.git`
-2. Install dependencies `yarn install`
-3. Run it `yarn build`
+2. Install dependencies `npm install`
+3. Run it `npm run build`

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   },
   "main": "src/index.ts",
   "scripts": {
-    "build": "webpack --progress --stats-error-details && node ./dist/bundle.js"
+    "build": "npx ts-node src/index.ts"
   },
-  "type": "commonjs",
   "devDependencies": {
     "@types/express": "^4.17.17",
     "@types/node": "^20.2.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "esModuleInterop" : true,
+    "esModuleInterop": true,
     "module": "ES2022",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
@@ -13,8 +13,13 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "ES2022"
+    "target": "ES6"
   },
   "include": ["./src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  }
 }


### PR DESCRIPTION
[Webpack](https://webpack.js.org/) seemed like too much bloat at this time so prefer [ts-node](https://www.npmjs.com/package/ts-node).